### PR TITLE
Feedback mj cp ls

### DIFF
--- a/pages/2_MUSTER_map.py
+++ b/pages/2_MUSTER_map.py
@@ -286,9 +286,9 @@ map_traces = st.session_state['map_traces_shared'] | map_traces_constant
 with containers['units_text']:
     outline_labels_dict = {
         'none': 'None',
+        'ambo22': 'Ambulance service',
         'icb': 'Integrated Care Board',
         'isdn': 'Integrated Stroke Delivery Network',
-        'ambo22': 'Ambulance service',
         'nearest_ivt_unit': 'Nearest IVT unit',
         'nearest_mt_unit': 'Nearest MT unit',
     }
@@ -826,9 +826,9 @@ for p, dp in dicts_colours.items():
 with containers['map_setup']:
     outline_labels_dict = {
         'none': 'None',
+        'ambo22': 'Ambulance service',
         'icb': 'Integrated Care Board',
         'isdn': 'Integrated Stroke Delivery Network',
-        'ambo22': 'Ambulance service',
     }
 
     def f(label):

--- a/pages/2_MUSTER_map.py
+++ b/pages/2_MUSTER_map.py
@@ -634,7 +634,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         ch = st.container(border=True, width=500)
     with ch:
         st.subheader(region_label)
-        st.write('summary summary summary bits')
+        st.write('Placeholder for most important summary results.')
 
     # Admissions
     s_admissions = (

--- a/pages/2_MUSTER_map.py
+++ b/pages/2_MUSTER_map.py
@@ -843,6 +843,13 @@ with containers['map_setup']:
         key='maps_outcomes_outline'
         )
 
+
+maps_to_show = ['usual_care', 'msu_minus_usual_care']
+with containers['map_fig']:
+    if st.toggle('Show population density map.',
+                 on_change=set_rerun_map, value=True):
+        maps_to_show.append('pop')
+
 if st.session_state['rerun_maps']:
     # Make traces for maps:
     for col, arr in st.session_state['map_arrs_dict'].items():
@@ -850,7 +857,7 @@ if st.session_state['rerun_maps']:
             arr, transform_dict, dicts_colours[col], name=col)
     st.session_state['maps_fig'] = plot_maps.plot_outcome_maps(
         map_traces,
-        ['usual_care', 'msu_minus_usual_care', 'pop'],
+        maps_to_show,
         dicts_colours,
         all_cmaps,
         outline_name,

--- a/pages/2_MUSTER_map.py
+++ b/pages/2_MUSTER_map.py
@@ -652,10 +652,13 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         # Only patients whose nearest unit does not have MT.
         n_admissions = s_admissions['admissions_nearest_unit_no_mt']
         prop_nearest_mt = 100.0
-        extra_str = f'''
-        Excluding {n_patients_nearest_mt:.0f} patients whose nearest unit
-        has MT.
-        '''
+        if n_patients_nearest_mt == 0.0:
+            extra_str = ''
+        else:
+            extra_str = f'''
+            Excluding {n_patients_nearest_mt:.0f} patients whose nearest unit
+            has MT.
+            '''
 
     with containers['region_treat_stats']:
         c = st.container(width=400, border=True)

--- a/pages/2_MUSTER_map.py
+++ b/pages/2_MUSTER_map.py
@@ -653,7 +653,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         n_admissions = s_admissions['admissions_nearest_unit_no_mt']
         prop_nearest_mt = 100.0
         extra_str = f'''
-        Excluding {n_patients_nearest_mt:.1f} patients whose nearest unit
+        Excluding {n_patients_nearest_mt:.0f} patients whose nearest unit
         has MT.
         '''
 
@@ -661,7 +661,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         c = st.container(width=400, border=True)
         with c:
             st.metric('Annual stroke admissions',
-                      f"{n_admissions:.1f}")
+                      f"{n_admissions:.0f}")
             n = 'Proportion of patients whose  \nnearest unit offers MT'
             st.metric(n, f"{prop_nearest_mt:.1f}%")
             st.markdown(extra_str)

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -1118,6 +1118,7 @@ with containers['map_setup_highlights']:
     subgroup_map, subgroup_map_label = maps.select_map_data(
         st.session_state['df_subgroups']
     )
+map_title = f'{subgroup_map_label} — of {str_this_population} ({prop_this_population:.1%} of all stroke)'
 with containers['map_setup_toggles']:
     use_full_redir = st.toggle(
         '''In middle map, include "reject redirection" and
@@ -1194,7 +1195,7 @@ if st.session_state['rerun_maps']:
         dicts_colours,
         all_cmaps,
         outline_name=outline_name,
-        title=subgroup_map_label,
+        title=map_title,
         )
     st.session_state['rerun_maps'] = False
 

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -724,7 +724,9 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         df_mt = df_mt.drop('Nearest unit has MT', axis='columns')
         df_ivt = df_ivt.drop('Nearest unit has MT', axis='columns')
         prop_nearest_mt = 100.0
-        if n_patients_nearest_mt > 0.0:
+        if n_patients_nearest_mt == 0.0:
+            extra_str = ''
+        else:
             extra_str = f'''
             Excluding {n_patients_nearest_mt:.0f} patients whose nearest unit
             has MT, including

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -685,9 +685,10 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
           dict_region_treat_stats[f'n_mt_{u_no_mt}_{red}_{r}']]],
         columns=['Nearest unit has MT', 'Not redirected', 'Redirected'],
         index=['Usual care', 'Redirection']
-    )
+    ).round(3)
     column_config_mt = dict([
-        (c, st.column_config.NumberColumn(width='small', format='%.0f'))
+        (c, st.column_config.NumberColumn(
+            width='small', format='%.0f admissions'))
         for c in df_mt.columns
         ])
     df_ivt = pd.DataFrame(
@@ -699,9 +700,10 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
           dict_region_treat_stats[f'n_ivt_only_{u_no_mt}_{red}_{r}']]],
         columns=['Nearest unit has MT', 'Not redirected', 'Redirected'],
         index=['Usual care', 'Redirection']
-    )
+    ).round(3)
     column_config_ivt_only = dict([
-        (c, st.column_config.NumberColumn(width='small', format='%.0f'))
+        (c, st.column_config.NumberColumn(
+            width='small', format='%.0f admissions'))
         for c in df_ivt.columns
         ])
 
@@ -902,7 +904,8 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
                 format='%.0f', width='small'),
         'admissions_first_unit_to_transfer_usual_care':
             st.column_config.NumberColumn(
-                label='Transfers (usual care)', format='%+.0f', width='small'),
+                label='Transfers (usual care)', format='%+.0f',
+                width='small'),
         'admissions_first_unit_to_transfer_redir':
             st.column_config.NumberColumn(
                 label='Transfers (redirection)',
@@ -913,6 +916,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         c = st.container(width=500, border=True)
         with c:
             st.subheader(region_label)
+            st.write('Numbers of admissions:')
 
             st.dataframe(
                 df_unit_admissions.round(0),

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -633,6 +633,12 @@ with containers['region_select']:
 lsoa_subset = 'nearest_unit_no_mt' if use_lsoa_subset else 'all_patients'
 
 # Set up containers for the outcome subgroups:
+label_redir = '''
+Redirection available<br>
+(mix of usual care,<br>
+redirection approved,<br>
+redirection rejected)
+'''
 with containers['region_summaries']:
     for s, subgroup in enumerate(st.session_state['df_subgroups'].index):
         containers[f'{subgroup}_top'] = st.expander(
@@ -642,7 +648,7 @@ with containers['region_summaries']:
         # Set up which bars to show on the mRS bar charts:
         options_labels = {
             'usual_care': 'Usual care',
-            'redir_allowed': 'Redirection available (mix of usual care, redirection approved, redirection rejected)',
+            'redir_allowed': label_redir,
             'redir_accept': 'Only redirected patients',
             'no_treatment': 'No treatment',
         }
@@ -1070,6 +1076,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
                         with st.container():
                             reg.display_region_summary(df_u, df_r, key)
 
+
                 mrs_lists_dict = {
                     'usual_care': {
                         'noncum': df_u[cols_mrs_noncum],
@@ -1083,7 +1090,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
                         'cum': df_r[cols_mrs],
                         'std': df_r[cols_mrs_std],
                         'colour': '#56b4e9',
-                        'label': 'Redirection available<br>(mix of usual care,<br>redirection approved,<br>redirection rejected)'
+                        'label': label_redir
                     },
                     'redir_accept': {
                         'noncum': df_a[cols_mrs_noncum],
@@ -1118,7 +1125,10 @@ with containers['map_setup_highlights']:
     subgroup_map, subgroup_map_label = maps.select_map_data(
         st.session_state['df_subgroups']
     )
-map_title = f'{subgroup_map_label} — of {str_this_population} ({prop_this_population:.1%} of all stroke)'
+map_title = f'''
+{subgroup_map_label} — of {str_this_population}
+({prop_this_population:.1%} of all stroke)
+'''
 with containers['map_setup_toggles']:
     use_full_redir = st.toggle(
         '''In middle map, include "reject redirection" and

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -154,6 +154,17 @@ def set_up_page_layout():
         c['map_fig'] = st.container()
         with st.expander('Accessibility & advanced map setup'):
             c['map_setup'] = st.container()
+    with c['map_fig']:
+        c['map_setup_highlights'] = st.container(border=True)
+    with c['map_setup_highlights']:
+        st.subheader('Patients included in the maps')
+        st.markdown('''
+                    Adjust the settings here to change which subgroup of
+                    patients is being shown.  
+                    More subgroups can be made available by adding
+                    them in the "Subgroups" tab in the Setup.
+                    ''')
+        c['map_setup_toggles'] = st.container(horizontal=True)
     with c['full_results']:
         c['full_results_setup'] = st.container()
 
@@ -1103,10 +1114,11 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
 with containers['map_setup']:
     map_outcome = outcomes.select_outcome_type()
 # Gather data for maps:
-with containers['map_fig']:
+with containers['map_setup_highlights']:
     subgroup_map, subgroup_map_label = maps.select_map_data(
         st.session_state['df_subgroups']
     )
+with containers['map_setup_toggles']:
     use_full_redir = st.toggle(
         '''In middle map, include "reject redirection" and
         "usual care" patients.''',
@@ -1114,8 +1126,7 @@ with containers['map_fig']:
         key='full_redir_subset',
         on_change=set_rerun_map
         )
-    redir_subset = ('redir_allowed' if use_full_redir
-                    else 'redir_accepted_only')
+redir_subset = ('redir_allowed' if use_full_redir else 'redir_accepted_only')
 
 if st.session_state['rerun_maps']:
     st.session_state['map_arrs_dict'], st.session_state['map_vlim_dict'] = (
@@ -1167,7 +1178,7 @@ with containers['map_setup']:
         )
 
 maps_to_show = ['usual_care', 'redir_minus_usual_care']
-with containers['map_fig']:
+with containers['map_setup_toggles']:
     if st.toggle('Show population density map.',
                  on_change=set_rerun_map, value=True):
         maps_to_show.append('pop')

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -687,7 +687,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         index=['Usual care', 'Redirection']
     )
     column_config_mt = dict([
-        (c, st.column_config.NumberColumn(width='small', format='%.1f'))
+        (c, st.column_config.NumberColumn(width='small', format='%.0f'))
         for c in df_mt.columns
         ])
     df_ivt = pd.DataFrame(
@@ -701,7 +701,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         index=['Usual care', 'Redirection']
     )
     column_config_ivt_only = dict([
-        (c, st.column_config.NumberColumn(width='small', format='%.1f'))
+        (c, st.column_config.NumberColumn(width='small', format='%.0f'))
         for c in df_ivt.columns
         ])
 
@@ -724,12 +724,13 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         df_mt = df_mt.drop('Nearest unit has MT', axis='columns')
         df_ivt = df_ivt.drop('Nearest unit has MT', axis='columns')
         prop_nearest_mt = 100.0
-        extra_str = f'''
-        Excluding {n_patients_nearest_mt:.1f} patients whose nearest unit
-        has MT, including
-        {n_mt_not_subset:.1f} patients who receive thrombectomy
-        and {n_ivt_only_not_subset:.1f} receieving thrombolysis only.
-        '''
+        if n_patients_nearest_mt > 0.0:
+            extra_str = f'''
+            Excluding {n_patients_nearest_mt:.0f} patients whose nearest unit
+            has MT, including
+            {n_mt_not_subset:.0f} patients who receive thrombectomy
+            and {n_ivt_only_not_subset:.0f} receieving thrombolysis only.
+            '''
 
     with containers['region_treat_stats']:
         c = st.container(width=500, border=True)
@@ -738,19 +739,19 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
             cols = st.columns(2)
             with cols[0]:
                 st.metric('Annual stroke admissions  \nin this population',
-                          f"{n_patients:.1f}")
+                          f"{n_patients:.0f}")
             n = 'Proportion of patients whose  \nnearest unit offers MT'
             with cols[1]:
                 st.metric(n, f"{prop_nearest_mt:.1f}%")
 
             st.markdown(f'''
-                Of the {n_mt:.1f} patients who receive thrombectomy
+                Of the {n_mt:.0f} patients who receive thrombectomy
                 (with or without thrombolysis):
                 ''')
             st.dataframe(df_mt, column_config=column_config_mt)
 
             st.markdown(f'''
-                Of the {n_ivt_only:.1f}
+                Of the {n_ivt_only:.0f}
                 patients who receive thrombolysis only:
                 ''')
             st.dataframe(df_ivt, column_config=column_config_ivt_only)
@@ -892,18 +893,18 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
                 label='Directly-admitting unit', width=150),
         'admissions_catchment_to_first_unit_usual_care':
             st.column_config.NumberColumn(
-                label='Usual care', format='%.2f', width='small'),
+                label='Usual care', format='%.0f', width='small'),
         'admissions_catchment_to_first_unit_redir':
             st.column_config.NumberColumn(
                 label='Redirection available',
-                format='%.2f', width='small'),
+                format='%.0f', width='small'),
         'admissions_first_unit_to_transfer_usual_care':
             st.column_config.NumberColumn(
-                label='t', format='%+.2f', width='small'),
+                label='t', format='%+.0f', width='small'),
         'admissions_first_unit_to_transfer_redir':
             st.column_config.NumberColumn(
                 label='t',
-                format='%+.2f', width='small')
+                format='%+.0f', width='small')
     }
 
     with containers['region_unit_admissions']:
@@ -912,7 +913,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
             st.subheader(region_label)
 
             st.dataframe(
-                df_unit_admissions,
+                df_unit_admissions.round(0),
                 # column_order=['admissions_combo_usual_care',
                 #               'admissions_combo_redir'],
                 column_order=['admissions_catchment_to_first_unit_usual_care',

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -160,9 +160,7 @@ def set_up_page_layout():
         st.subheader('Patients included in the maps')
         st.markdown('''
                     Adjust the settings here to change which subgroup of
-                    patients is being shown.  
-                    More subgroups can be made available by adding
-                    them in the "Subgroups" tab in the Setup.
+                    patients is being shown.
                     ''')
         c['map_setup_toggles'] = st.container(horizontal=True)
     with c['full_results']:
@@ -623,8 +621,9 @@ with containers['results_top']:
     st.markdown(f'''
                 Results are given for only this population:
                 "__{str_this_population}__"
-                ({prop_this_population:.1%} of all stroke).
-                ''')
+                ({prop_this_population:.1%} of all stroke).  
+                __More subgroups__ can be made available by adding
+                them in the "Subgroups" tab in the Setup.''')
 with containers['region_select']:
     use_lsoa_subset = st.toggle(
         'Exclude patients whose nearest unit provides MT.',
@@ -641,8 +640,10 @@ redirection rejected)
 '''
 with containers['region_summaries']:
     for s, subgroup in enumerate(st.session_state['df_subgroups'].index):
+        label_subgroup = 'Outcomes for __:primary[' + (
+            st.session_state['df_subgroups'].loc[subgroup, 'label']) + ']__'
         containers[f'{subgroup}_top'] = st.expander(
-            st.session_state['df_subgroups'].loc[subgroup, 'label'],
+            label_subgroup,
             expanded=(True if s == 0 else False)
             )
         # Set up which bars to show on the mRS bar charts:
@@ -1047,7 +1048,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         with c:
             st.subheader(region_label)
             st.markdown(f'''
-                For only this population:
+                {label_subgroup} in
                 "__{str_this_population}__"
                 ({prop_this_population:.1%} of all stroke).
                 ''')

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -609,7 +609,11 @@ else:
 
 # Display chosen results:
 with containers['results_top']:
-    st.markdown(f'Results are given for only this population: "__{str_this_population}__" ({prop_this_population:.1%} of all stroke).')
+    st.markdown(f'''
+                Results are given for only this population:
+                "__{str_this_population}__"
+                ({prop_this_population:.1%} of all stroke).
+                ''')
 with containers['region_select']:
     use_lsoa_subset = st.toggle(
         'Exclude patients whose nearest unit provides MT.',
@@ -748,7 +752,11 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         c = st.container(width=500, border=True)
         with c:
             st.subheader(region_label)
-            st.markdown(f'For only patients in the population: __{str_this_population}__ ({prop_this_population:.1%} of all stroke).')
+            st.markdown(f'''
+                For only this population:
+                "__{str_this_population}__"
+                ({prop_this_population:.1%} of all stroke).
+                ''')
             cols = st.columns(2)
             with cols[0]:
                 st.metric(f'Annual stroke admissions  \nin this population:',
@@ -791,7 +799,11 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         c = st.container(width=500, border=True)
         with c:
             st.subheader(region_label)
-            st.markdown(f'For only patients in the population: __{str_this_population}__ ({prop_this_population:.1%} of all stroke).')
+            st.markdown(f'''
+                For only this population:
+                "__{str_this_population}__"
+                ({prop_this_population:.1%} of all stroke).
+                ''')
             if selected_region_is_mt_unit:
                 st.markdown('No data to display.')
             else:
@@ -926,7 +938,11 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         c = st.container(width=500, border=True)
         with c:
             st.subheader(region_label)
-            st.markdown(f'For only patients in the population: __{str_this_population}__ ({prop_this_population:.1%} of all stroke).')
+            st.markdown(f'''
+                For only this population:
+                "__{str_this_population}__"
+                ({prop_this_population:.1%} of all stroke).
+                ''')
             st.write('Numbers of admissions:')
 
             st.dataframe(
@@ -983,7 +999,11 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
                     region_label = df_unit_services.loc[region, 'ssnap_name']
                 else:
                     region_label = region
-                st.markdown(f'For only patients in the population: __{str_this_population}__ ({prop_this_population:.1%} of all stroke).')
+                st.markdown(f'''
+                    For only this population:
+                    "__{str_this_population}__"
+                    ({prop_this_population:.1%} of all stroke).
+                    ''')
                 # Plot graph:
                 plot_maps.plot_networks(
                     df_net_u, df_net_r, df_unit_services, gdf_nearest_units,
@@ -1009,7 +1029,11 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
             c = st.container(width=500, border=True)
         with c:
             st.subheader(region_label)
-            st.markdown(f'For only patients in the population: __{str_this_population}__ ({prop_this_population:.1%} of all stroke).')
+            st.markdown(f'''
+                For only this population:
+                "__{str_this_population}__"
+                ({prop_this_population:.1%} of all stroke).
+                ''')
             df_u = st.session_state['dict_highlighted_region_outcomes'][
                 subgroup]['usual_care'][lsoa_subset]
             df_r = st.session_state['dict_highlighted_region_outcomes'][

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -320,9 +320,9 @@ map_traces = st.session_state['map_traces_shared'] | map_traces_constant
 with containers['units_text']:
     outline_labels_dict = {
         'none': 'None',
+        'ambo22': 'Ambulance service',
         'icb': 'Integrated Care Board',
         'isdn': 'Integrated Stroke Delivery Network',
-        'ambo22': 'Ambulance service',
         'nearest_ivt_unit': 'Nearest IVT unit',
         'nearest_mt_unit': 'Nearest MT unit',
     }
@@ -1105,9 +1105,9 @@ for p, dp in dicts_colours.items():
 with containers['map_setup']:
     outline_labels_dict = {
         'none': 'None',
+        'ambo22': 'Ambulance service',
         'icb': 'Integrated Care Board',
         'isdn': 'Integrated Stroke Delivery Network',
-        'ambo22': 'Ambulance service',
     }
 
     def f(label):

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -642,8 +642,8 @@ with containers['region_summaries']:
         # Set up which bars to show on the mRS bar charts:
         options_labels = {
             'usual_care': 'Usual care',
-            'redir_allowed': 'Redirection available',
-            'redir_accept': 'Accept redirection',
+            'redir_allowed': 'Redirection available (mix of usual care, redirection approved, redirection rejected)',
+            'redir_accept': 'Only redirected patients',
             'no_treatment': 'No treatment',
         }
 
@@ -1083,14 +1083,14 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
                         'cum': df_r[cols_mrs],
                         'std': df_r[cols_mrs_std],
                         'colour': '#56b4e9',
-                        'label': 'Redirection available'
+                        'label': 'Redirection available<br>(mix of usual care,<br>redirection approved,<br>redirection rejected)'
                     },
                     'redir_accept': {
                         'noncum': df_a[cols_mrs_noncum],
                         'cum': df_a[cols_mrs],
                         'std': df_a[cols_mrs_std],
                         'colour': '#009e73',
-                        'label': 'Accept redirection'
+                        'label': 'Only redirected patients'
                     },
                     'no_treatment': {
                         'noncum': df_no_treat[cols_mrs_noncum],

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -129,6 +129,7 @@ def set_up_page_layout():
     tabs_results = ['Region summaries', 'England maps', 'Full results tables']
     with c['results']:
         st.header('Results')
+        c['results_top'] = st.container()
         (c['region_summaries'], c['maps'], c['full_results']) = (
             st.tabs(tabs_results))
 
@@ -387,6 +388,11 @@ with containers['onion_text']:
     dict_onion = pop.select_onion_population(df_onion_pops)
 dict_onion = pop.calculate_population_subgroups(
     dict_onion, _log_loc=containers['log_onion'])
+# Keep a copy of the label for this population.
+# Use it throughout the results to make it clearer which patients
+# are included.
+str_this_population = dict_onion['label']
+prop_this_population = dict_onion['prop_of_all_stroke']
 
 
 # ----- Subgroups (this onion layer) -----
@@ -602,6 +608,8 @@ else:
     pass
 
 # Display chosen results:
+with containers['results_top']:
+    st.markdown(f'Results are given for only this population: "__{str_this_population}__" ({prop_this_population:.1%} of all stroke).')
 with containers['region_select']:
     use_lsoa_subset = st.toggle(
         'Exclude patients whose nearest unit provides MT.',
@@ -740,9 +748,10 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         c = st.container(width=500, border=True)
         with c:
             st.subheader(region_label)
+            st.markdown(f'For only patients in the population: __{str_this_population}__ ({prop_this_population:.1%} of all stroke).')
             cols = st.columns(2)
             with cols[0]:
-                st.metric('Annual stroke admissions  \nin this population',
+                st.metric(f'Annual stroke admissions  \nin this population:',
                           f"{n_patients:.0f}")
             n = 'Proportion of patients whose  \nnearest unit offers MT'
             with cols[1]:
@@ -782,6 +791,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         c = st.container(width=500, border=True)
         with c:
             st.subheader(region_label)
+            st.markdown(f'For only patients in the population: __{str_this_population}__ ({prop_this_population:.1%} of all stroke).')
             if selected_region_is_mt_unit:
                 st.markdown('No data to display.')
             else:
@@ -916,6 +926,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
         c = st.container(width=500, border=True)
         with c:
             st.subheader(region_label)
+            st.markdown(f'For only patients in the population: __{str_this_population}__ ({prop_this_population:.1%} of all stroke).')
             st.write('Numbers of admissions:')
 
             st.dataframe(
@@ -972,6 +983,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
                     region_label = df_unit_services.loc[region, 'ssnap_name']
                 else:
                     region_label = region
+                st.markdown(f'For only patients in the population: __{str_this_population}__ ({prop_this_population:.1%} of all stroke).')
                 # Plot graph:
                 plot_maps.plot_networks(
                     df_net_u, df_net_r, df_unit_services, gdf_nearest_units,
@@ -997,6 +1009,7 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
             c = st.container(width=500, border=True)
         with c:
             st.subheader(region_label)
+            st.markdown(f'For only patients in the population: __{str_this_population}__ ({prop_this_population:.1%} of all stroke).')
             df_u = st.session_state['dict_highlighted_region_outcomes'][
                 subgroup]['usual_care'][lsoa_subset]
             df_r = st.session_state['dict_highlighted_region_outcomes'][

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -1122,6 +1122,12 @@ with containers['map_setup']:
         key='maps_outcomes_outline'
         )
 
+maps_to_show = ['usual_care', 'redir_minus_usual_care']
+with containers['map_fig']:
+    if st.toggle('Show population density map.',
+                 on_change=set_rerun_map, value=True):
+        maps_to_show.append('pop')
+
 if st.session_state['rerun_maps']:
     # Make traces for maps:
     for col, arr in st.session_state['map_arrs_dict'].items():
@@ -1129,7 +1135,7 @@ if st.session_state['rerun_maps']:
             arr, transform_dict, dicts_colours[col], name=col)
     st.session_state['maps_fig'] = plot_maps.plot_outcome_maps(
         map_traces,
-        ['usual_care', 'redir_minus_usual_care', 'pop'],
+        maps_to_show,
         dicts_colours,
         all_cmaps,
         outline_name=outline_name,

--- a/pages/2_OPTIMIST_map.py
+++ b/pages/2_OPTIMIST_map.py
@@ -255,7 +255,7 @@ selected subgroup of patients.
 with containers['region_unit_admissions_top']:
     st.markdown('''
 Total patients from this catchment area
-directly admitted to (and transferred "t" to or from)
+directly admitted to (and transferred to or from)
 each unit:
 ''')
 with containers['region_unit_maps_top']:
@@ -902,10 +902,10 @@ for r, region in enumerate(df_highlighted_regions['highlighted_region']):
                 format='%.0f', width='small'),
         'admissions_first_unit_to_transfer_usual_care':
             st.column_config.NumberColumn(
-                label='t', format='%+.0f', width='small'),
+                label='Transfers (usual care)', format='%+.0f', width='small'),
         'admissions_first_unit_to_transfer_redir':
             st.column_config.NumberColumn(
-                label='t',
+                label='Transfers (redirection)',
                 format='%+.0f', width='small')
     }
 

--- a/utilities/maps.py
+++ b/utilities/maps.py
@@ -34,7 +34,7 @@ def select_map_data(df_subgroups: pd.DataFrame):
         return dict_labels[label]
     # Pick a layer to use for calculating population results:
     key = st.selectbox(
-        'Choose a population to show on the maps.',
+        '__:primary[Choose a subgroup]__ to show on the maps.',
         options=df_subgroups.index,
         format_func=f,
         index=0,

--- a/utilities/plot_maps.py
+++ b/utilities/plot_maps.py
@@ -1779,7 +1779,7 @@ def plot_networks(
                     axis=-1
                     ),
                 hovertemplate=(
-                    '%{customdata[2]:.1f} patients from catchment area of ' +
+                    '%{customdata[2]:.0f} patients from catchment area of ' +
                     '<br>' +
                     '%{customdata[0]}' +
                     '<br>' +
@@ -1865,7 +1865,7 @@ def plot_networks(
                         axis=-1
                         ),
                     hovertemplate=(
-                        '%{customdata[2]:.1f} patients transfer from ' +
+                        '%{customdata[2]:.0f} patients transfer from ' +
                         '<br>' +
                         '%{customdata[0]}' +
                         '<br>' +
@@ -1910,7 +1910,7 @@ def plot_networks(
         hovertemplate=(
             'Catchment area of<br>%{customdata[0]}' +
             '<br>' +
-            '%{customdata[1]:.1f} patients' +
+            '%{customdata[1]:.0f} patients' +
             # Need the following line to remove default "trace" bit
             # in second "extra" box:
             '<extra></extra>'

--- a/utilities/plot_maps.py
+++ b/utilities/plot_maps.py
@@ -1590,9 +1590,11 @@ def plot_outcome_maps(
     # --- Layout ---
     fig = england_map_setup(fig)
     # Figure setup.
+    # Allow two subplots to be taller (800px) than three (600px).
+    h = 1200 - 200 * len(map_order)
     fig.update_layout(
         # width=1200,
-        height=600,
+        height=h,
         margin_t=80,
         margin_b=0,
         )

--- a/utilities/regions.py
+++ b/utilities/regions.py
@@ -279,27 +279,27 @@ def select_unit_services_muster(
         # i = 0
         # with cols[i % n_cols]:
         add_all_ivt = st.button('Place MSU at all IVT-only units',
-                                on_click=set_inputs_changed)
+                                on_click=set_rerun_lsoa_units_times)
         # i += 1
         # with cols[i % n_cols]:
         add_all_mt = st.button('Place MSU at all MT units',
-                               on_click=set_inputs_changed)
+                               on_click=set_rerun_lsoa_units_times)
         # i += 1
         # with cols[i % n_cols]:
         add_all = st.button('Place MSU at all units',
-                            on_click=set_inputs_changed)
+                            on_click=set_rerun_lsoa_units_times)
         # i += 1
         # with cols[i % n_cols]:
         remove_all_ivt = st.button('Remove MSU from all IVT-only units',
-                                   on_click=set_inputs_changed)
+                                   on_click=set_rerun_lsoa_units_times)
         # i += 1
         # with cols[i % n_cols]:
         remove_all_mt = st.button('Remove MSU from all MT units',
-                                  on_click=set_inputs_changed)
+                                  on_click=set_rerun_lsoa_units_times)
         # i += 1
         # with cols[i % n_cols]:
         remove_all = st.button('Remove MSU from all units',
-                               on_click=set_inputs_changed)
+                               on_click=set_rerun_lsoa_units_times)
 
     # Which units need to be changed in each case:
     units_ivt_bool = (

--- a/utilities/regions.py
+++ b/utilities/regions.py
@@ -1212,7 +1212,7 @@ def plot_mrs_bars(mrs_lists_dict: dict, key: str = None):
         orientation='h'
     ))
     # Figure setup.
-    fig.update_layout(height=250, margin_t=0)
+    fig.update_layout(height=350, margin_t=0)
     fig = update_plotly_font_sizes(fig)
     fig.update_layout(title='')
     # Turn off legend click events

--- a/utilities/regions.py
+++ b/utilities/regions.py
@@ -939,10 +939,10 @@ def load_region_lists(df_unit_services: pd.DataFrame):
 
     # Key for region type, value for list of options.
     region_options_dict = {
+        'Ambulance service': ambo_list,
         'ISDN': isdn_list,
         'ICB': icb_list,
         'Nearest unit': nearest_ivt_unit_names_list,
-        'Ambulance service': ambo_list
     }
 
     return region_options_dict
@@ -1276,7 +1276,7 @@ def select_full_data_type():
         'Choose a region type for the full results.',
         options=region_types,
         format_func=f,
-        index=3,
+        index=4,
         on_change=set_rerun_full_results
         )
     return full_data_type


### PR DESCRIPTION
Implement feedback from MJ, CP, and LS. Mostly cosmetic changes.

New:
+ show/hide population density map
+ clearer how to select other patient subgroups
+ units in results tables where possible
+ admissions rounded to integers for display
+ clearer that admissions are for selected onion layer, not necessarily the full stroke population
+ clearer labelling of columns in tables of admissions and transfers by unit
+ scenario options labelled more clearly (was redirection available vs redirection accepted)
+ ambulance regions made more prominent in region selects

Not yet implemented:
+ Relabel nLVO/LVO - need snappier titles
+ choose main summary results
+ related - how best to summarise benefit for those eligible for MT vs disbenefit for those not eligible for MT?